### PR TITLE
Retry Logic Improvements etc

### DIFF
--- a/constants/blockchain.go
+++ b/constants/blockchain.go
@@ -3,6 +3,10 @@ package constants
 type Blockchain string
 
 const (
+	BlockKey = "block"
+)
+
+const (
 	UNKNOWN             = "unknown"
 	Ethereum Blockchain = "ethereum"
 	Polygon  Blockchain = "polygon"

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/datadaodevs/go-service-framework
 
 go 1.20
 
-replace github.com/datadaodevs/go-service-framework => /Users/robinarenson/src/coherent/go-service-framework
-
 require (
 	github.com/DataDog/datadog-go/v5 v5.3.0
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/datadaodevs/go-service-framework
 
 go 1.20
 
-replace github.com/datadaodevs/go-service-framework => /Users/robin/src/coherent/go-service-framework
+replace github.com/datadaodevs/go-service-framework => /Users/robinarenson/src/coherent/go-service-framework
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.3.0

--- a/poller/poller.go
+++ b/poller/poller.go
@@ -47,6 +47,7 @@ func New(cfg *PollerConfig, driver Driver, opts ...opt) *Poller {
 // Run executes the main program loop inside of a dedicated goroutine; the loop can be terminated from the
 // outside via context cancellation
 func (p *Poller) Run(ctx context.Context) error {
+	p.logger.Infof("Main poller worker starting for blockchain [%s]", p.driver.Blockchain())
 	go func() {
 		for {
 			//	Check for context cancellation
@@ -64,6 +65,8 @@ func (p *Poller) Run(ctx context.Context) error {
 				p.logger.Errorf("Error setting mode: %v", err)
 				continue
 			}
+
+			p.logger.Infof("Top of main loop; mode is [%s]", p.mode)
 
 			switch p.mode {
 			case ModeSleep:

--- a/poller/sequencing.go
+++ b/poller/sequencing.go
@@ -59,7 +59,6 @@ func (p *Poller) setCurrentChaintip(ctx context.Context, newTip uint64) error {
 
 // getRemoteChaintip pulls the remote chaintip value
 func (p *Poller) getRemoteChaintip(ctx context.Context) (uint64, error) {
-	fmt.Println("here!")
 	var chainTip uint64
 	var err error
 	retry.Exec(p.cfg.HttpRetries, func() error {

--- a/poller/sequencing.go
+++ b/poller/sequencing.go
@@ -59,6 +59,7 @@ func (p *Poller) setCurrentChaintip(ctx context.Context, newTip uint64) error {
 
 // getRemoteChaintip pulls the remote chaintip value
 func (p *Poller) getRemoteChaintip(ctx context.Context) (uint64, error) {
+	fmt.Println("here!")
 	var chainTip uint64
 	var err error
 	retry.Exec(p.cfg.HttpRetries, func() error {

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -17,13 +17,16 @@ func Exec(maxRetries int, fn RunnerFunc, sleep SleeperFunc) error {
 	var err error
 	attempt := 1
 	for {
-		if err = fn(); err != nil {
-			attempt++
-			if attempt > maxRetries {
-				break
-			}
-			sleep(attempt)
+		err = fn()
+		if err == nil {
+			return nil
 		}
+		attempt++
+		if attempt > maxRetries {
+			break
+		}
+		sleep(attempt)
+		continue
 	}
 	return err
 }


### PR DESCRIPTION
Small changes to service framework to make it more useful to other codebases:

- Adding "block" as a shared public constant, for use in naming of output files
- Retry utility updated to include a default exponential backoff and the option of passing in a custom backoff algorithm if desired