### PR TITLE
[feature] adding config to poller to enable trace-only polling

### DIFF
--- a/poller/config.go
+++ b/poller/config.go
@@ -7,12 +7,13 @@ import (
 )
 
 type Config struct {
-	Blockchain  constants.Blockchain `env:"BLOCKCHAIN,required"`
-	BatchSize   int                  `env:"BATCH_SIZE" envDefault:"100"`
-	ReorgDepth  int                  `env:"REORG_DEPTH" envDefault:"8"`
-	HttpRetries int                  `env:"HTTP_RETRIES" envDefault:"10"`
-	SleepTime   time.Duration        `env:"POLLER_SLEEP_TIME" envDefault:"12s"`
-	Tick        time.Duration        `env:"POLLER_TICK_DURATION" envDefault:"1s"`
-	AutoStart   bool                 `env:"POLLER_AUTO_START" envDefault:"false"`
-	CursorKey   string               `env:"CURSOR_KEY" envDefault:""`
+	Blockchain      constants.Blockchain `env:"BLOCKCHAIN,required"`
+	BatchSize       int                  `env:"BATCH_SIZE" envDefault:"100"`
+	ReorgDepth      int                  `env:"REORG_DEPTH" envDefault:"8"`
+	HttpRetries     int                  `env:"HTTP_RETRIES" envDefault:"10"`
+	SleepTime       time.Duration        `env:"POLLER_SLEEP_TIME" envDefault:"12s"`
+	Tick            time.Duration        `env:"POLLER_TICK_DURATION" envDefault:"1s"`
+	AutoStart       bool                 `env:"POLLER_AUTO_START" envDefault:"false"`
+	CursorKey       string               `env:"CURSOR_KEY" envDefault:""`
+	IsTraceBackfill bool                 `env:"IS_TRACE_BACKFILL" envDefault:"false"`
 }

--- a/poller/poller.go
+++ b/poller/poller.go
@@ -67,6 +67,9 @@ func New(cfg *Config, driver Driver, opts ...opt) *Poller {
 
 	p.cursorKey = strings.TrimSpace(cfg.CursorKey)
 	if p.cursorKey == "" {
+		if p.cfg.IsTraceBackfill {
+			p.logger.Fatal("cursor key must be set when trace backfill is enabled")
+		}
 		p.cursorKey = fmt.Sprintf("%s-%s", p.driver.Blockchain(), constants.BlockKey)
 	}
 


### PR DESCRIPTION
RPC nodes are unreliable when it comes to fetching traces. (`debug_traceBlockByNumber`)
To leverage our existing poller to fetch traces, I added a configuration variable.

cursor key must be different from our existing pollers, since it will overwrite the cache